### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/sharenixlib/clipboard.go
+++ b/sharenixlib/clipboard.go
@@ -33,7 +33,7 @@ func GetClipboard() *gtk.Clipboard {
 	return gtk.NewClipboardGetForDisplay(display, gdk.SELECTION_CLIPBOARD)
 }
 
-// SetClipbboardText sets the clipboard text contents and calls
+// SetClipboardText sets the clipboard text contents and calls
 // clipboard.Store().
 // Note: this requires the program to run at least a few cycles of the main loop
 // and it is not guaranteed to persist on all window managers once the program

--- a/sharenixlib/paths.go
+++ b/sharenixlib/paths.go
@@ -43,7 +43,7 @@ func GetHome() (res string) {
 	return
 }
 
-// Returns the path to the storage directory
+// GetStorageDir returns the path to the storage directory
 func GetStorageDir() (res string, err error) {
 	cfg, err := LoadConfig()
 

--- a/sharenixlib/utils.go
+++ b/sharenixlib/utils.go
@@ -89,7 +89,7 @@ func MkDirIfNotExists(dir string) error {
 	return nil
 }
 
-// Returns the current year and month in format "2019-01"
+// GetDate returns the current year and month in format "2019-01"
 func GetDate() string {
 	ye := time.Now().Year()
 	mo := time.Now().Month()


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?