### PR TITLE
Specify User-Agent on HTTP requests

### DIFF
--- a/sharenixlib/requests.go
+++ b/sharenixlib/requests.go
@@ -174,6 +174,7 @@ func SendRequest(method, url, fileParamName, filePath string,
 	}
 
 	// extra headers
+	req.Header.Set("User-Agent", strings.Replace(ShareNixVersion, " ", "/", 1))
 	for hname, hval := range extraHeaders {
 		req.Header.Set(hname, hval)
 	}

--- a/sharenixlib/sharenix.go
+++ b/sharenixlib/sharenix.go
@@ -65,6 +65,7 @@ func fakeResponseStart(code int, body string) (*httptest.Server, *http.Client) {
 	server = httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(code)
+			w.Header().Set("User-Agent", strings.Replace(ShareNixVersion, " ", "/", 1))
 			w.Header().Set("Content-Type", "plain/text")
 			fmt.Fprintln(w, body)
 		}),


### PR DESCRIPTION
Using the format specified over at: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent

It was previously `Go-http-client/1.1` which is not very useful to service operators reading logs.