### PR TITLE
Added flameshot support

### DIFF
--- a/sharenix-section
+++ b/sharenix-section
@@ -28,7 +28,9 @@ sharenixtmp=$(mktemp /tmp/nicememe.XXXXXXXXXXXXXXXXXXX)
 mv "$sharenixtmp" "$sharenixtmp.png"
 sharenixtmp="$sharenixtmp.png"
 
-if command -v gnome-screenshot > /dev/null 2>&1; then
+if command -v flameshot > /dev/null 2>&1; then
+    flameshot gui --raw > $sharenixtmp || exit $?
+elif command -v gnome-screenshot > /dev/null 2>&1; then
     gnome-screenshot -a -f $sharenixtmp || exit $?
 elif command -v maim > /dev/null 2>&1; then
     maim -s $sharenixtmp || exit $?


### PR DESCRIPTION
Added support for [flameshot](https://flameshot.js.org/), which has some nice annotation possibilities.
Downside is that they don't have a window-capture mode (or at least, not that I could find, I hadn't heard from the project till an hour ago :P)

I've put it first as it's pretty rich in features, while gnome-screenshot might also still be installed as it's default in Gnome I assume.